### PR TITLE
Updates for 1.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/modules/ROOT/examples/transactions-example.cxx
+++ b/modules/ROOT/examples/transactions-example.cxx
@@ -140,7 +140,7 @@ main(int argc, const char* argv[])
 {
     // #tag::config_trace[]
     // Set logging level to Trace
-    couchbase::transactions::set_transactions_logging_level(log_levels::TRACE);
+    couchbase::transactions::set_transactions_logging_level(log_level::TRACE);
     // #end::config_trace[]
 
     // #tag::init[]
@@ -209,21 +209,21 @@ main(int argc, const char* argv[])
                 // Use ctx.get_optional() if the document may or may not exist
                 auto doc_opt = ctx.get_optional(collection, "doc-a");
                 if (doc_opt) {
-                    couchbase::transactions::transaction_document& doc = doc_opt.value();
+                    couchbase::transactions::transaction_get_result& doc = doc_opt.value();
                 }
 
                 // Use ctx.get if the document should exist, and the transaction
                 // will fail if it does not
-                couchbase::transactions::transaction_document doc_a = ctx.get(collection, "doc-a");
+                couchbase::transactions::transaction_get_result doc_a = ctx.get(collection, "doc-a");
 
                 // Replacing a doc:
-                couchbase::transactions::transaction_document doc_b = ctx.get(collection, "doc-b");
+                couchbase::transactions::transaction_get_result doc_b = ctx.get(collection, "doc-b");
                 nlohmann::json content = doc_b.content<nlohmann::json>();
                 content["transactions"] = "are awesome";
                 ctx.replace(collection, doc_b, content);
 
                 // Removing a doc:
-                couchbase::transactions::transaction_document doc_c = ctx.get(collection, "doc-c");
+                couchbase::transactions::transaction_get_result doc_c = ctx.get(collection, "doc-c");
                 ctx.remove(collection, doc_c);
 
                 ctx.commit();
@@ -252,7 +252,7 @@ main(int argc, const char* argv[])
             std::string id = "doc-a";
             auto doc_opt = ctx.get_optional(collection, id);
             if (doc_opt) {
-                couchbase::transactions::transaction_document& doc = doc_opt.value();
+                couchbase::transactions::transaction_get_result& doc = doc_opt.value();
             }
         });
         // #end::get[]
@@ -267,7 +267,7 @@ main(int argc, const char* argv[])
             };
             ctx.insert(collection, id, value);
             // document must be accessible
-            couchbase::transactions::transaction_document doc = ctx.get(collection, id);
+            couchbase::transactions::transaction_get_result doc = ctx.get(collection, id);
         });
         // #end::getReadOwnWrites[]
     }
@@ -276,7 +276,7 @@ main(int argc, const char* argv[])
         // tag::replace[]
         transactions.run([&](couchbase::transactions::attempt_context& ctx) {
             std::string id = "doc-a";
-            couchbase::transactions::transaction_document doc = ctx.get(collection, id);
+            couchbase::transactions::transaction_get_result doc = ctx.get(collection, id);
             nlohmann::json content = doc.content<nlohmann::json>();
             content["transactions"] = "are awesome";
             ctx.replace(collection, doc, content);
@@ -300,7 +300,7 @@ main(int argc, const char* argv[])
         int cost_of_item = 10;
         // #tag::rollback[]
         transactions.run([&](couchbase::transactions::attempt_context& ctx) {
-            couchbase::transactions::transaction_document customer = ctx.get(collection, "customer-name");
+            couchbase::transactions::transaction_get_result customer = ctx.get(collection, "customer-name");
 
             auto content = customer.content<nlohmann::json>();
             int balance = content["balance"].get<int>();

--- a/modules/ROOT/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/ROOT/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -15,10 +15,10 @@ The {cpp} Transactions API is built upon the Couchbase C SDK, _libcouchbase_ (LC
 Applications built using C SDK and C Transactions can run in parallel without interfering with each other.
 
 Below we show you how to create Transactions, step-by-step.
-You may also want to start with our https://github.com/couchbaselabs/couchbase-transactions-java-examples[transactions examples repository],
+You may also want to start with our https://github.com/couchbaselabs/couchbase-transactions-cxx-examples[transactions examples repository],
 which features useful downloadable examples of using Distributed Transactions.
 
-API docs are available https://docs.couchbase.com/sdk-api/couchbase-transactions-cxx-1.0.0-beta.1/index.html[online].
+API docs are available https://docs.couchbase.com/sdk-api/couchbase-transactions-cxx-1.0.0/index.html[online].
 
 
 == Requirements
@@ -31,9 +31,18 @@ include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
 Couchbase transactions require no additional components or services to be configured.
 Simply add the transactions library into your project.
-The latest version, as of October 2020, is 1.0.0.beta.1.
+The latest version, as of 19 April 2021, is 1.0.0.
 
-The following steps show how to build and run our example project on CentOS 8:
+=== Installing on Linux
+
+We are currently distributing our linux libraries in tar files, which can be found:
+
+* RHEL7/Centos7 - `https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-1.253.el7.x86_64.tar`
+* RHEL8/Centos8 - `https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-1.253.el8.x86_64.tar`
+* Debian10 - `https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0~r253-debian10-buster.tar`
+* Ubuntu 20.04 - `https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0~r253-ubuntu2004-focal.tar`
+
+The following steps show how to install transactions on RHEL/CentOS 8.  Other linux platforms will be similar:
 
 [source,console]
 ----
@@ -43,10 +52,23 @@ $ sudo yum install boost-devel
 
 [source,console]
 ----
-$ wget https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar
-$ tar xf couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar
+$ wget https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-1.253.el8.x86_64.tar
+$ tar xf couchbase-transactions-1.0.0-1.253.el8.x86_64.tar
 $ sudo yum install couchbase-transactions*.rpm
 ----
+
+=== Installing on Mac OS X
+
+Mac libraries are available through https://brew.sh[homebrew].  To install, once you have homebrew:
+
+[source,console]
+----
+$ brew install couchbase-transactions-cxx
+----
+
+=== Build and run example project
+
+On Linux or Mac OSX, building and running the example project is the same:
 
 [source,console]
 ----
@@ -55,11 +77,6 @@ $ cd couchbase-transactions-cxx-examples/game/
 $ mkdir build && cd build
 $ cmake ../
 $ make
-----
-
-[source,console]
-----
-$ ./game_server
 ----
 
 == Initializing Transactions
@@ -191,7 +208,7 @@ include::example$transactions-example.cxx[tag=threads,indent=0]
 // == A Full Transaction Example
 include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=example]
 
-A complete version of this example is available on our https://github.com/couchbaselabs/couchbase-transactions-java-examples[GitHub transactions examples page].
+A complete version of this example is available on our https://github.com/couchbaselabs/couchbase-transactions-cxx-examples[GitHub transactions examples page].
 
 [source,c++]
 ----

--- a/modules/ROOT/pages/distributed-transactions-cxx-release-notes.adoc
+++ b/modules/ROOT/pages/distributed-transactions-cxx-release-notes.adoc
@@ -23,9 +23,9 @@ This page features the release notes for that library -- for release notes, down
 
 [source,console]
 ----
-$ wget https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar
+$ wget https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-1.253.el8.x86_64.tar
 
-$ tar xf couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar
+$ tar xf couchbase-transactions-1.0.0-1.253.el8.x86_64.tar
 
 $ sudo yum install couchbase-transactions*.rpm
 ----
@@ -34,9 +34,9 @@ $ sudo yum install couchbase-transactions*.rpm
 
 [source,console]
 ----
-$ wget https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0.beta.1~r63-debian10-buster.tar
+$ wget https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0~r253-debian10-buster.tar
 
-$ tar xf couchbase-transactions-1.0.0.beta.1~r63-debian10-buster.tar
+$ tar xf couchbase-transactions-1.0.0~r253-debian10-buster.tar
 
 $ sudo apt-get install -y libevent-core-2.1
 
@@ -45,6 +45,15 @@ $ sudo dpkg -i couchbase-transactions*.deb
 
 // 1.0.0 release notes here:
 [#latest-release]
+== Version 1.0.0 (19 April 2021)
+
+* Supports couchbase server 6.6.1 and later.
+* Transactions for KV operations only (no query transactions yet)
+* Synchronous kv transaction operations (no async transaction operations yet)
+* Minimal c++ client included.
+
+=== Known issues
+
 == Version 1.0.0 Beta 1 (13 October 2020)
 
 First beta release of 1.0.0
@@ -52,9 +61,8 @@ First beta release of 1.0.0
 
 === Known Issues
 
-* Owing to https://issues.couchbase.com/browse/MB-41944[MB-41944], this release _should not be used together with a deployment using Sync Gateway_.  
-Owing to this issue there is also a known theoretical data loss problem.  
-This release (as with all beta releases) should not be used in production.  
+* Owing to https://issues.couchbase.com/browse/MB-41944[MB-41944], this release _should not be used together with a deployment using Sync Gateway_.
+Owing to this issue there is also a known theoretical data loss problem.
 The issue will be fixed in Couchbase Server release 6.6.1.
 
 
@@ -64,10 +72,10 @@ The issue will be fixed in Couchbase Server release 6.6.1.
 [cols="12,^8,23"]
 |===
 | Platform              | Architecture | File
-| Enterprise Linux 7    | x64          | https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-0.beta.1.63.el7.x86_64.tar[couchbase-transactions-1.0.0-0.beta.1.63.el7.x86_64.tar]
-| Enterprise Linux 8    | x64          | https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar[couchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar]
-| Ubuntu 20.04 (focal)  | x64          | https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0.beta.1%7Er63-ubuntu2004-focal.tar[couchbase-transactions-1.0.0.beta.1~r63-ubuntu2004-focal.tar]
-| Debian 10 (buster)    | x64          | https://sdk-snapshots.couchbase.com/clients/transactions-cxx/couchbase-transactions-1.0.0.beta.1%7Er63-debian10-buster.tar[couchbase-transactions-1.0.0.beta.1~r63-debian10-buster.tar]
+| Enterprise Linux 7    | x64          | https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-cxx-1.0.0-1.253.el7.x86_64.tar[couchbase-transactions-1.0.0-0.beta.1.63.el7.x86_64.tar]
+| Enterprise Linux 8    | x64          | https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-cxx-1.0.0-1.253.el8.x86_64.tarcouchbase-transactions-1.0.0-0.beta.1.63.el8.x86_64.tar]
+| Ubuntu 20.04 (focal)  | x64          | https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-cxx-1.0.0~r253-debian10-buster.tar[couchbase-transactions-1.0.0.beta.1~r63-ubuntu2004-focal.tar]
+| Debian 10 (buster)    | x64          | https://packages.couchbase.com/clients/transactions-cxx/couchbase-transactions-cxx-1.0.0~r253-ubuntu2004-focal.tar[couchbase-transactions-1.0.0.beta.1~r63-debian10-buster.tar]
 |===
 
 
@@ -75,5 +83,3 @@ The issue will be fixed in Couchbase Server release 6.6.1.
 
 See the xref:6.6@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
 The xref:distributed-acid-transactions-from-the-sdk.adoc[Distributed Transactions HOWTO doc] walks you through all aspects of working with Distributed Transactions.
-
-


### PR DESCRIPTION
* correct urls for downloads
* mention of mac installation
* fixup any mention of `transaction_document`, as it is `transaction_get_result` now
* fixup `log_levels`, no longer plural.